### PR TITLE
[Hotfix] Spotify Display Name

### DIFF
--- a/server/app/controller.py
+++ b/server/app/controller.py
@@ -24,10 +24,10 @@ app.add_middleware(
 
 @app.post("/auth-codes", status_code=status.HTTP_201_CREATED, response_model=Token)
 async def authorize_spotify(host: SpotifyUser) -> Token:
-    host.username = service.get_spotify_name()
+    spotify_token = service.get_spotify_token(host)
+    host.username = service.get_display_name(spotify_token)
     host = await service.create_user(host)
-    token_info = service.spotify_oauth.get_access_token(host.auth_code)
-    return service.generate_token(host, Token(**token_info))
+    return service.generate_token(host, spotify_token)
 
 
 @app.post("/token", status_code=status.HTTP_201_CREATED, response_model=Token)

--- a/server/app/models/token.py
+++ b/server/app/models/token.py
@@ -5,6 +5,9 @@ from typing import Optional
 class Token(BaseModel):
     access_token: str
     token_type: str
+
+
+class SpotifyToken(Token):
     expires_in: Optional[int] = None
     refresh_token: Optional[str] = None
     scope: Optional[str] = None

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -1,6 +1,7 @@
 from typing import Optional, List
 from pydantic import BaseModel
 
+
 class User(BaseModel):
     id: Optional[str] = None
     username: str
@@ -8,4 +9,5 @@ class User(BaseModel):
 
 
 class SpotifyUser(User):
+    username: Optional[str] = None
     auth_code: str

--- a/server/app/service.py
+++ b/server/app/service.py
@@ -107,8 +107,7 @@ class Service:
 
     def get_spotify_token(self, host: SpotifyUser) -> SpotifyToken:
         try:
-            # TODO: whenever host is verified, cached token is used even if auth_code is invalid
-            spotify_token_info = self.spotify_oauth.get_access_token(host.auth_code)
+            spotify_token_info = self.spotify_oauth.get_access_token(host.auth_code, check_cache=False)
             return SpotifyToken(**spotify_token_info)
         except SpotifyOauthError:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authorization code")


### PR DESCRIPTION
When an invalid auth_code is used for the first time, an exception is raised. However, once a valid auth_code is used, Spotipy caches the token. After that the cached token is used _even if_ the auth_code is **invalid**. This might be an issue for which a workaround would be to manually delete the cache file. But then authorization is necessary for every step we use the api for :(